### PR TITLE
Add Google Fonts description HTML

### DIFF
--- a/documentation/DESCRIPTION.en_us.html
+++ b/documentation/DESCRIPTION.en_us.html
@@ -1,0 +1,13 @@
+<p>
+Cairo is a contemporary Arabic and Latin typeface family.
+Mohamed Gaber extended the Latin typeface family <a href="https://fonts.google.com/specimen/Titillium+Web">Titillum Web</a> to support the Arabic script, with a design that is based on the Kufi calligraphic style. Now available as a variable font.
+</p>
+<p>
+Cairo balances classic and contemporary tastes with wide open counters and short ascenders and descenders that minimize length while maintaining easy readability. 
+The lighter weights can be used for body text while the heavier weights are perfect for headlines and display typography. 
+Each font includes stylistic ligatures and the Arabic component has a wide glyph set that supports the Arabic, Farsi and Urdu languages.
+</p>
+<p>
+The Cairo project is led by Mohamed Gaber, a type designer based in Cairo, Egypt. 
+To contribute, see <a href="https://github.com/Gue3bara/Cairo">github.com/Gue3bara/Cairo</a>
+</p>


### PR DESCRIPTION
This is the description HTML used on the Google Fonts website. Keeping a copy in the upstream repository should make it easier to update. See the screenshot below:

![description](https://user-images.githubusercontent.com/5162664/77093412-4c7c6400-69e1-11ea-85e4-13e3d8bd8e2c.png)
